### PR TITLE
Update API endpoint for GeoIP web services

### DIFF
--- a/bin/weather
+++ b/bin/weather
@@ -18,7 +18,7 @@ def get_location():
     """Return current location as latitude/longitude tuple."""
     logger.debug("query MaxMind for location")
     r = requests.get(
-        "https://www.maxmind.com/geoip/v2.1/city/me",
+        "https://geoip.maxmind.com/geoip/v2.1/city/me",
         headers={"referer": "https://www.maxmind.com/en/locate-my-ip-address"},
         timeout=10,
     )


### PR DESCRIPTION
MaxMind is beginning to enforce policies around its API endpoints. Endpoints should use the correct hostname for the product or service, and should always use HTTPS.

[Release Note.](https://dev.maxmind.com/geoip/release-notes/2023#api-policies---temporary-enforcement-on-october-17-2023)